### PR TITLE
Bump base to 4.9

### DIFF
--- a/smallcheck-series.cabal
+++ b/smallcheck-series.cabal
@@ -31,7 +31,7 @@ library
                        Test.SmallCheck.Series.Text
                        Test.SmallCheck.Series.Text.Lazy
                        Test.SmallCheck.Series.Utils
-  build-depends:       base >=4.6 && <4.9,
+  build-depends:       base >=4.6 && <4.10,
                        bytestring >=0.10.0.2,
                        containers >=0.5.0.0,
                        text >=0.11.3,
@@ -45,6 +45,6 @@ test-suite doctests
   hs-source-dirs:      tests
   main-is:             doctests.hs
   ghc-options:         -Wall -threaded
-  build-depends:       base >=4.6 && <4.9,
+  build-depends:       base >=4.6 && <4.10,
                        Glob >=0.7.5,
                        doctest >=0.9.10


### PR DESCRIPTION
I've tested build on ghc-8.0 -- it works fine.