### PR TITLE
Version bump

### DIFF
--- a/Test/SmallCheck/Series/Instances.hs
+++ b/Test/SmallCheck/Series/Instances.hs
@@ -76,9 +76,6 @@ coInts rs =
       | i < 0 -> g ((abs i - 1))
       | otherwise -> z
 
-instance Monad m => Serial m Word where series = nats0
-instance Monad m => CoSerial m Word where coseries = conats0
-
 instance Monad m => Serial m Word8 where series = nats0
 instance Monad m => CoSerial m Word8 where coseries = conats0
 

--- a/smallcheck-series.cabal
+++ b/smallcheck-series.cabal
@@ -32,7 +32,7 @@ library
                        Test.SmallCheck.Series.Text
                        Test.SmallCheck.Series.Text.Lazy
                        Test.SmallCheck.Series.Utils
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.12,
                        bytestring >=0.10.0.2,
                        containers >=0.5.0.0,
                        text >=0.11.3,
@@ -46,6 +46,6 @@ test-suite doctests
   hs-source-dirs:      tests
   main-is:             doctests.hs
   ghc-options:         -Wall -threaded
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.12,
                        Glob >=0.7.5,
                        doctest >=0.9.10

--- a/smallcheck-series.cabal
+++ b/smallcheck-series.cabal
@@ -38,7 +38,7 @@ library
                        text >=0.11.3,
                        transformers >=0.3.0.0,
                        logict >=0.6.0.2,
-                       smallcheck >=1.1.1
+                       smallcheck >=1.1.3
 
 test-suite doctests
   default-language:    Haskell2010


### PR DESCRIPTION
Now supporting smallcheck-1.1.3 and GHC 8.4.

Note that since you're not using upper bounds, cabal users currently encounter a compilation error if they attempt to build smallcheck-series. The problem is that the latest version of smallcheck, smallcheck-1.1.3.1, is within the range `>= 1.1.1`, and yet smallcheck-series fails to build with that version of smallcheck. The reason is that smallcheck-1.1.3 introduces instances for `Word`, which conflict with your instances. This PR fixes this problem, but since you're not using upper bounds, a similar problem could occur in the future.

Stack users can't use the current version of smallcheck-series with the latest LTS either, but for a slightly different reason. The latest LTS, lts-11.0, uses base-4.10.1.0 and smallcheck-1.1.3.1; the problem with smallcheck-1.1.3.1 is as above, while the problem with base-4.10.1.0 is that this version is outside of your version bounds. This PR fixes this problem, but of course the latest LTS is a moving target so similar problems may occur in the future no matter what.