### PR TITLE
Support smallcheck versions 1.1.1 to 1.1.5. Resolves #11

### DIFF
--- a/Test/SmallCheck/Series/Instances.hs
+++ b/Test/SmallCheck/Series/Instances.hs
@@ -48,6 +48,8 @@ import qualified Data.Map as Map
 import Test.SmallCheck.Series
 import Control.Monad.Logic (interleave)
 
+#if !MIN_VERSION_smallcheck(1,1,4)
+
 instance Monad m => Serial m Int8 where series = ints
 instance Monad m => CoSerial m Int8 where coseries = coInts
 
@@ -76,6 +78,11 @@ coInts rs =
       | i < 0 -> g ((abs i - 1))
       | otherwise -> z
 
+#if !MIN_VERSION_smallcheck(1,1,3)
+instance Monad m => Serial m Word where series = nats0
+instance Monad m => CoSerial m Word where coseries = conats0
+#endif
+
 instance Monad m => Serial m Word8 where series = nats0
 instance Monad m => CoSerial m Word8 where coseries = conats0
 
@@ -99,6 +106,8 @@ conats0 rs =
     if n > 0
         then f (n-1)
         else z
+
+#endif
 
 instance Monad m => Serial m B.ByteString where
     series = cons0 B.empty \/ cons2 B.cons

--- a/smallcheck-series.cabal
+++ b/smallcheck-series.cabal
@@ -38,7 +38,7 @@ library
                        text >=0.11.3,
                        transformers >=0.3.0.0,
                        logict >=0.6.0.2,
-                       smallcheck >=1.1.3
+                       smallcheck >=1.1.1
 
 test-suite doctests
   default-language:    Haskell2010


### PR DESCRIPTION
If you don't want to use CPP for this I can make another pull request where I just drop compatibility for `smallcheck < 1.1.5`.