### PR TITLE
Make zipLogic and zipLogic3 compatible with logict-0.7.1.0

### DIFF
--- a/Test/SmallCheck/Series/Utils.hs
+++ b/Test/SmallCheck/Series/Utils.hs
@@ -8,7 +8,10 @@ module Test.SmallCheck.Series.Utils
   , zipLogic3
   ) where
 
-import Control.Monad.Logic ((<=<), MonadLogic(msplit), lift, mplus, mzero)
+import Control.Applicative (empty, (<|>))
+import Control.Monad ((<=<))
+import Control.Monad.Logic (MonadLogic(msplit))
+import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 
 -- $setup
@@ -32,10 +35,10 @@ import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 -- Thanks to Roman Cheplyaka: https://groups.google.com/d/msg/haskell-tasty/k0dXCx9EBsc/XYkCTjYKqswJ
 zipLogic :: MonadLogic m => m a -> m b -> m (a, b)
 zipLogic gx gy =
-  maybe mzero return <=< runMaybeT $ do
+  maybe empty pure <=< runMaybeT $ do
     (x, rx) <- MaybeT (msplit gx)
     (y, ry) <- MaybeT (msplit gy)
-    lift $ return (x, y) `mplus` zipLogic rx ry
+    lift $ pure (x, y) <|> zipLogic rx ry
 
 -- | /One-to-One/ zipping of 3 'MonadLogic' instances. You can use for
 --   'Test.SmallCheck.Series' like this:
@@ -46,8 +49,8 @@ zipLogic gx gy =
 -- Thanks to Roman Cheplyaka: https://groups.google.com/d/msg/haskell-tasty/k0dXCx9EBsc/XYkCTjYKqswJ
 zipLogic3 :: MonadLogic m => m a -> m b -> m c -> m (a, b, c)
 zipLogic3 gx gy gz =
-  maybe mzero return <=< runMaybeT $ do
+  maybe empty pure <=< runMaybeT $ do
     (x, rx) <- MaybeT (msplit gx)
     (y, ry) <- MaybeT (msplit gy)
     (z, rz) <- MaybeT (msplit gz)
-    lift $ return (x, y, z) `mplus` zipLogic3 rx ry rz
+    lift $ pure (x, y, z) <|> zipLogic3 rx ry rz


### PR DESCRIPTION
The latest `logict` relaxes superclasses of `MonadLogic`. Previously it required `MonadPlus` (which in its turn requires both `Monad` and `Alternative`), but now it requires `Monad` and `Alternative` directly. This was not meant to be breaking (bad judgement on my side), but unfortunately if a function requires `MonadLogic m` only, now it cannot immediately use `mzero` and `mplus`.  This PR fixes `zipLogic` and `zipLogic3` to comply with the new definition of `MonadLogic`. 

I have also restructured import lists: it is better to import `lift` and `(<=<)` from their native modules than rely on re-exports from `logict`. There is a long running discussion that `mtl` should stop re-exporting `Control.Monad` and `Control.Monad.Trans.Class` from every module, and as soon as this is implemented in `mtl`, `logict` will follow the suite.